### PR TITLE
Createing '/driverrider endpoint'

### DIFF
--- a/src/main/java/project/controller/DriverRiderController.java
+++ b/src/main/java/project/controller/DriverRiderController.java
@@ -1,0 +1,44 @@
+package project.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import project.mockservice.MockDataService;
+import project.responseentities.DriverRiderResponse;
+import project.service.UserService;
+
+/**
+ * Created by olafurorn on 10/1/15.
+ */
+@Controller
+public class DriverRiderController
+{
+    private static final String LOGTAG = DriverRiderController.class.getSimpleName();
+
+    private final UserService userModel;
+    private final MockDataService mockDataService;
+
+
+    @Autowired
+    public DriverRiderController(UserService userModel, MockDataService mockDataService)
+    {
+        this.userModel = userModel;
+        this.mockDataService = mockDataService;
+    }
+
+    @RequestMapping(value = "/driverrider", method = RequestMethod.GET)
+    public ResponseEntity<DriverRiderResponse> login(
+            //@RequestParam(value="accessToken") String accessToken, TODO: check the accessToken
+    )
+    {
+        // user exist and we return 200
+        DriverRiderResponse driverRiderResponse = new DriverRiderResponse(
+                mockDataService.getMockDriverList(),
+                mockDataService.getMockRiderList());
+        return new ResponseEntity<DriverRiderResponse>(driverRiderResponse, HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/project/controller/RouterController.java
+++ b/src/main/java/project/controller/RouterController.java
@@ -6,11 +6,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 @Controller
-public class HomeController
+public class RouterController
 {
-    private static final String LOGTAG = HomeController.class.getSimpleName();
+    private static final String LOGTAG = RouterController.class.getSimpleName();
 
-    public HomeController()
+    public RouterController()
     {
 
     }

--- a/src/main/java/project/responseentities/DriverRiderResponse.java
+++ b/src/main/java/project/responseentities/DriverRiderResponse.java
@@ -1,0 +1,31 @@
+package project.responseentities;
+
+import project.responseentities.subentities.DriverListEntry;
+import project.responseentities.subentities.RiderListEntry;
+
+import java.util.List;
+
+/**
+ * Created by olafurorn on 10/1/15.
+ */
+public class DriverRiderResponse
+{
+    private final List<DriverListEntry> driversList;
+    private final List<RiderListEntry> ridersList;
+
+    public DriverRiderResponse(List<DriverListEntry> driversList, List<RiderListEntry> ridersList)
+    {
+        this.driversList = driversList;
+        this.ridersList = ridersList;
+    }
+
+    public List<DriverListEntry> getDriversList()
+    {
+        return driversList;
+    }
+
+    public List<RiderListEntry> getRidersList()
+    {
+        return ridersList;
+    }
+}


### PR DESCRIPTION
@hlynurf @pajdak3 
Ég var að búa til endapunktinn `/driverrider` (hann skila núna fake-harðkóðuðum gögnum þar sem skráning fyrir driver og rider er ekki tilbúið)

Þannig þegar síðan `/main` er opnuð þá getiði kallað í þennan endapunkt til að fá lista af driverum og riderum til að setja upp í lista