### PR TITLE
Call /driverrider endpoint from web

### DIFF
--- a/src/main/webapp/resources/theme1/src/servercalls.js
+++ b/src/main/webapp/resources/theme1/src/servercalls.js
@@ -1,0 +1,13 @@
+/**
+ * Created by olafurorn on 10/6/15.
+ */
+function getDriverRiderList() {
+    $.ajax({
+        type: 'GET',
+        url: '/driverrider',
+        data: response,
+        success: function(data) {
+            console.log("Data from /driverrider endpoint: " + data);
+        }
+    });
+}


### PR DESCRIPTION
Call `/driverrider` endpoint from web to show drivers and riders on the `/main` webpage