### PR TITLE
Access token

### DIFF
--- a/src/main/java/misc/Log.java
+++ b/src/main/java/misc/Log.java
@@ -24,6 +24,24 @@ public class Log
     }
 
     /**
+     * Warnign logging
+     */
+    public static void w(final String LOGTAG, final String msg)
+    {
+        System.out.println("warning - " + LOGTAG + " : " + msg);
+    }
+
+    /**
+     * Warnign logging
+     */
+    public static void w(final String LOGTAG, Exception e)
+    {
+        System.out.println("warning - " + LOGTAG);
+        System.out.println(" - STACKTRACE: ");
+        e.printStackTrace();;
+    }
+
+    /**
      * Error logging
      */
     public static void e(final String LOGTAG, final Exception e)

--- a/src/main/java/project/mockservice/MockDataService.java
+++ b/src/main/java/project/mockservice/MockDataService.java
@@ -59,7 +59,7 @@ public class MockDataService
 
         for (int i = 0; i < NUMBER_OF_MOCK_RIDER; i++)
         {
-            RiderListEntry riderListEntry = new RiderListEntry(new User(getRandomId(), getRandomName(),
+            RiderListEntry riderListEntry = new RiderListEntry(new User("test_access_token", getRandomId(), getRandomName(),
                     getRandomEmail(), getRandomRatings(), getRandomNumberOfRatings()),
                     getRandomLocation(), getRandomLocation(), getRandomDateInTheFuture());
             riderListEntries.add(riderListEntry);
@@ -74,7 +74,7 @@ public class MockDataService
 
         for (int i = 0; i < NUMBER_OF_MOCK_DRIVER; i++)
         {
-            DriverListEntry driverListEntry = new DriverListEntry(new User(getRandomId(), getRandomName(),
+            DriverListEntry driverListEntry = new DriverListEntry(new User("test_access_token", getRandomId(), getRandomName(),
                     getRandomEmail(), getRandomRatings(), getRandomNumberOfRatings()),
                     getRandomDateInTheFuture(), getRandomDateInTheFuture());
             driverListEntries.add(driverListEntry);

--- a/src/main/java/project/responseentities/subentities/User.java
+++ b/src/main/java/project/responseentities/subentities/User.java
@@ -11,14 +11,17 @@ import project.serverentities.FullUser;
  */
 public class User
 {
-    private final String id;
+    private final String accessToken; // we user the fb accessToken to make our platform more secure
+    private final String id; // we use the fb id as the user id for our platform
     private final String name;
     private final String email;
     private final double starRating;
     private final int numberOfStarRatings;
 
-    public User(String id, String name, String email, double starRating, int numberOfStarRatings)
+    public User(String accessToken, String id, String name, String email,
+                double starRating, int numberOfStarRatings)
     {
+        this.accessToken = accessToken;
         this.id = id;
         this.name = name;
         this.email = email;
@@ -48,5 +51,10 @@ public class User
     public int getNumberOfStarRatings()
     {
         return numberOfStarRatings;
+    }
+
+    public String getAccessToken()
+    {
+        return accessToken;
     }
 }

--- a/src/main/java/project/service/DatabaseConstants.java
+++ b/src/main/java/project/service/DatabaseConstants.java
@@ -9,6 +9,7 @@ public class DatabaseConstants
     /******* TABLE: USERS *******/
     public static final String TABLE_USERS = "users";
     public static final String TABLE_USERS_COLUMN_USER_ID = "user_id";
+    public static final String TABLE_USERS_ACCESS_TOKEN = "access_token";
     public static final String TABLE_USERS_COLUMN_NAME = "name";
     public static final String TABLE_USERS_COLUMN_EMAIL = "email";
     public static final String TABLE_USERS_COLUMN_STAR_RATING = "star_rating";

--- a/src/main/java/project/service/UserService.java
+++ b/src/main/java/project/service/UserService.java
@@ -3,9 +3,14 @@ package project.service;
 import misc.Log;
 import org.springframework.stereotype.Service;
 import project.responseentities.subentities.User;
+import project.service.exceptions.UnauthorizedException;
 
 import java.net.URISyntaxException;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
 
 /**
  * Created by olafurorn on 9/30/15.
@@ -26,7 +31,7 @@ public class UserService extends AbstractService
      * @return null if user doesn't exist in database
      *         else the user object
      */
-    public User getUser(String userId)
+    public User getUser(String userId, String accessTokenFromClient) throws UnauthorizedException
     {
         User user = null;
         try
@@ -46,8 +51,11 @@ public class UserService extends AbstractService
                 final String email = resultSet.getString(DatabaseConstants.TABLE_USERS_COLUMN_EMAIL);
                 final double starRating = resultSet.getDouble(DatabaseConstants.TABLE_USERS_COLUMN_STAR_RATING);
                 final int numberOfStarRatings = resultSet.getInt(DatabaseConstants.TABLE_USERS_COLUMN_NUMBER_OF_STAR_RATINGS);
+                final String accessToken = resultSet.getString(DatabaseConstants.TABLE_USERS_ACCESS_TOKEN);
 
-                user = new User(id, name, email, starRating, numberOfStarRatings);
+                checkIfExistingUserIsAuthorized(id, accessToken, accessTokenFromClient);
+
+                user = new User(accessToken, id, name, email, starRating, numberOfStarRatings);
             }
 
             resultSet.close();
@@ -64,9 +72,6 @@ public class UserService extends AbstractService
 
 
 
-
-
-
         if (user == null)
         {
             Log.i(LOGTAG, "User, id: " + userId + ", does NOT exist in database");
@@ -79,37 +84,59 @@ public class UserService extends AbstractService
         return user;
     }
 
+    private void checkIfExistingUserIsAuthorized(final String userId, final String accessTokenFromDatabase,
+                                                 final String accessTokenFromWebPage) throws UnauthorizedException
+    {
+        if (userId == null || userId.isEmpty()
+                || accessTokenFromWebPage == null || accessTokenFromWebPage.isEmpty()
+                || accessTokenFromDatabase == null || accessTokenFromDatabase.isEmpty()
+                || !accessTokenFromDatabase.equals(accessTokenFromWebPage))
+        {
+            throw new UnauthorizedException();
+        }
+    }
+
 
     /**
      * Create user in database
      */
-    public void createUser(String id, String name, String email)
+    public String createUser(String id, String name, String email)
     {
+        String generatedAccessToken = null;
         try
         {
             Connection connection = getConnectionToDatabase();
 
             final String sqlQuery = "INSERT  INTO " + DatabaseConstants.TABLE_USERS + " (" +
                     DatabaseConstants.TABLE_USERS_COLUMN_USER_ID + ", " +
+                    DatabaseConstants.TABLE_USERS_ACCESS_TOKEN + ", " +
                     DatabaseConstants.TABLE_USERS_COLUMN_NAME + ", " +
                     DatabaseConstants.TABLE_USERS_COLUMN_EMAIL
-                    + ") VALUES (?,?,?);";
+                    + ") VALUES (?,?,?,?);";
             PreparedStatement preparedStatement = connection.prepareStatement(sqlQuery);
             preparedStatement.setString(1, id);
-            preparedStatement.setString(2, name);
-            preparedStatement.setString(3, email);
+            generatedAccessToken = generateUUID();
+            preparedStatement.setString(2, generatedAccessToken);
+            preparedStatement.setString(3, name);
+            preparedStatement.setString(4, email);
             preparedStatement.execute();
 
             preparedStatement.close();
         }
         catch (URISyntaxException e)
         {
-            Log.e(LOGTAG, "Couldn't get user", e);
+            Log.e(LOGTAG, "Couldn't create user", e);
         }
         catch (SQLException e)
         {
-            Log.e(LOGTAG, "Couldn't get user", e);
+            Log.e(LOGTAG, "Couldn't create user", e);
         }
 
+        return generatedAccessToken;
+    }
+
+    private String generateUUID()
+    {
+        return UUID.randomUUID().toString();
     }
 }

--- a/src/main/java/project/service/exceptions/UnauthorizedException.java
+++ b/src/main/java/project/service/exceptions/UnauthorizedException.java
@@ -1,0 +1,12 @@
+package project.service.exceptions;
+
+/**
+ * Created by olafurorn on 10/6/15.
+ */
+public class UnauthorizedException extends Exception
+{
+    public UnauthorizedException()
+    {
+        super("User is not authorized");
+    }
+}

--- a/src/main/webapp/WEB-INF/jsp/Index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/Index.jsp
@@ -41,7 +41,7 @@
   </nav>
   <header class="bg-header">
     <h1>Hermes</h1>
-    <button class="btn btn-block btn-social btn-facebook"><i class="fa fa-facebook"></i>Sign in with Facebook</button>
+    <button class="btn btn-block btn-social btn-facebook"><i class="fa fa-facebook"></i>Skr&aacute;&eth;u &thorn;ig inn me&eth; facebook</button>
   </header>
   <main>
     <div class="first_block_container">

--- a/src/main/webapp/WEB-INF/jsp/Main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/Main.jsp
@@ -3,8 +3,6 @@
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <html lang="is">
-<!-- TODO: olafur: update after this PR has been merged end fixed: https://github.com/pajdak3/hermes-server/pull/11
-                    so when the webpage create this page it has to send the accessToken-->
 <head>
     <meta charset="UTF-8">
     <title>Hermes</title>

--- a/src/main/webapp/WEB-INF/jsp/Main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/Main.jsp
@@ -3,6 +3,8 @@
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <html lang="is">
+<!-- TODO: olafur: update after this PR has been merged end fixed: https://github.com/pajdak3/hermes-server/pull/11
+                    so when the webpage create this page it has to send the accessToken-->
 <head>
     <meta charset="UTF-8">
     <title>Hermes</title>

--- a/src/main/webapp/resources/theme1/src/facebook.js
+++ b/src/main/webapp/resources/theme1/src/facebook.js
@@ -78,7 +78,7 @@ window.fbAsyncInit = function() {
 //  See statusChangeCallback() for when this call is made.
 function callFbGraphApi(accessToken) {
     console.log('Welcome!  Fetching your information.... ');
-    FB.api('/me?fields=id,name,email', function(response) {
+    FB.api('/me?fields=id,name,email,picture,first_name', function(response) {
         response.accessToken = accessToken;
         console.log('Successful login for: ' + response.name);
         console.log(response);

--- a/src/main/webapp/resources/theme1/src/facebook.js
+++ b/src/main/webapp/resources/theme1/src/facebook.js
@@ -81,14 +81,14 @@ function callFbGraphApi(accessToken) {
     FB.api('/me?fields=id,friends,name,email,picture,first_name', function(response) {
         response.accessToken = accessToken;
         console.log('Successful login for: ' + response.name);
-        console.log(response);
+        console.log('Data from FB graph api: ' + response);
         response.accessToken = accessToken;
         $.ajax({
             type: 'POST',
             url: '/login',
             data: response,
             success: function(data) {
-                console.log(data);
+                console.log('Data from server: ' + data);
             }
         });
         document.getElementById('app').innerHTML =

--- a/src/main/webapp/resources/theme1/src/facebook.js
+++ b/src/main/webapp/resources/theme1/src/facebook.js
@@ -81,14 +81,16 @@ function callFbGraphApi(accessToken) {
     FB.api('/me?fields=id,friends,name,email,picture,first_name', function(response) {
         response.accessToken = accessToken;
         console.log('Successful login for: ' + response.name);
-        console.log('Data from FB graph api: ' + response);
+        console.log('Data from FB graph api:');
+        console.log(response);
         response.accessToken = accessToken;
         $.ajax({
             type: 'POST',
             url: '/login',
             data: response,
             success: function(data) {
-                console.log('Data from server: ' + data);
+                console.log('Data from server:');
+                console.log(data);
             }
         });
         document.getElementById('app').innerHTML =

--- a/src/main/webapp/resources/theme1/src/facebook.js
+++ b/src/main/webapp/resources/theme1/src/facebook.js
@@ -78,7 +78,7 @@ window.fbAsyncInit = function() {
 //  See statusChangeCallback() for when this call is made.
 function callFbGraphApi(accessToken) {
     console.log('Welcome!  Fetching your information.... ');
-    FB.api('/me?fields=id,name,email,picture,first_name', function(response) {
+    FB.api('/me?fields=id,friends,name,email,picture,first_name', function(response) {
         response.accessToken = accessToken;
         console.log('Successful login for: ' + response.name);
         console.log(response);


### PR DESCRIPTION
Add Access token on the server
**so the flow is:**
1. user press login with facebook (but he is actually signing up on our platform)
2. the web calls the `/login` endpoint
3. the server check if this is new user or old, if it is new then the server create access token and return it back to the web
4. the web has to save this access token in the browser or something similar
5. next when you call the `/login` endpoint the web has to check if the access token is saved in the browser and if so, then send it to the server when you call the `/login` endpoint
6. the server check if the user is new or old, if old, it check if the access token is correct, if not, then it return 401 else it return 200

**What is left, is step 5 and 6** i.e. the web implementation, and I haven't done this on a web before, i.e. saving data in the browser and getting data saved in the browser.
Can you @hlynurf  or @pajdak3 take this branch and finish step 5 and 6 and push your changes ?